### PR TITLE
Remove contributors from the release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,19 +19,6 @@ template: |
   ## What's changed
 
   $CHANGES
-
-  ## Contributors to this release
-
-  $CONTRIBUTORS
-replacers:
-  - search: '/(?:and )?@dependabot-preview(?:\[bot\])?,?/g'
-    replace: ""
-  - search: '/(?:and )?@dependabot(?:\[bot\])?,?/g'
-    replace: ""
-  - search: '/(?:and )?@scala-steward(?:\[bot\])?,?/g'
-    replace: ""
-  - search: '/(?:and )?@alejandrohdezma-steward(?:\[bot\])?,?/g'
-    replace: ""
 autolabeler:
   - label: "enhancement"
     branch:


### PR DESCRIPTION
GitHub already includes this list on releases by default