### PR TITLE
Upgrade `release.yml` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
+# Don't edit this file!
+# It is automatically updated after every release of https://github.com/alejandrohdezma/sbt-ci
+# If you want to suggest a change, please open a PR or issue in that repository
+
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags: [v*]
   workflow_dispatch:
 
 jobs:
@@ -31,17 +35,15 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
   release:
-    if: github.event_name == 'release'
-    name: Release a new version of the artifact and update documentation
+    if: github.event_name == 'push'
+    name: Release a new version of the artifact
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout project
-        uses: actions/checkout@v2.3.4
+      - name: Checkout project (current ref)
+        uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
-          ref: main
-      - name: Fetch tags
-        run: git fetch --prune --unshallow --tags
       - name: Enable Coursier cache
         uses: coursier/cache-action@v6
       - name: Setup Coursier
@@ -57,6 +59,19 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  update_documentation:
+    if: github.event_name == 'push'
+    name: Updates documentation
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - name: Checkout project (main branch)
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+      - name: Fetch tags
+        run: git fetch --prune --unshallow --tags
       - name: Generate documentation
         run: sbt ci-docs
         env:

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ Copied to `.github/workflows/release.yml`.
 - Creates a release of the project by running `sbt ci-publish` (this task should be added to the project as a command alias containing the necessary steps to do a release). An example of this alias can be found [here](https://github.com/alejandrohdezma/sbt-github/blob/main/build.sbt#L7).
 - Runs `sbt ci-docs` on the project and pushes a commit with the changes (the `ci-docs` task should be added to the project as a command alias containing the necessary steps to update documentation: re-generate docs files, publish websites, update headers...). And example of this alias can be found [here](https://github.com/alejandrohdezma/sbt-github/blob/main/build.sbt#L6).
 
-It will launch on new releases. Alternatively one can launch it manually using a "workflow dispatch" to create a snapshot release.
+It will launch on pushed tags. Alternatively one can launch it manually using a "workflow dispatch" to create a snapshot release.
 
 > All the workflows need specific secrets to be enabled in the repository.
 


### PR DESCRIPTION
This PR changes the `release` workflow to launch on pushed tags (instead of releases). It also separates the release/generate-documentation features.

This change allows a multibranch repository (such as [http4s-munit](https://github.com/alejandrohdezma/http4s-munit)) to release correctly while maintaining documentation on the `main` branch.