### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           github-token: ${{ steps.github_app.outputs.token }}
 
   labeler:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     name: Labeler
     runs-on: ubuntu-latest
     steps:
@@ -93,7 +93,7 @@ jobs:
 
   test:
     needs: [labeler, ci-steward]
-    if: always() && !contains(needs.*.result, 'failure') && github.event_name == 'pull_request'
+    if: always() && !contains(needs.*.result, 'failure') && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     name: Run "sbt ci-test" on JDK ${{ matrix.jdk }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/update-gh-actions.yml
+++ b/.github/workflows/update-gh-actions.yml
@@ -1,0 +1,38 @@
+name: Update GitHub Actions comments on Dependabot PRs
+
+on:
+  pull_request_target:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  update-github-actions-comments:
+    name: Update GitHub Actions comments
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get `alejandrohdezma-steward` token
+        uses: alejandrohdezma/actions/github-app-token@v1
+        id: github_app
+        with:
+          token: ${{ secrets.GH_APP_TOKEN }}
+
+      - name: Checkout project
+        uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2.3.5
+        with:
+          token: ${{ steps.github_app.outputs.token }}
+          ref: ${{ github.head_ref }}
+
+      - name: Update action comments
+        id: update-github-actions
+        uses: alejandrohdezma/actions/update-github-actions@v1
+
+      - name: Commit new changes
+        uses: alejandrohdezma/actions/commit-and-push@v1
+        with:
+          message: >
+            Update ${{ steps.update-github-actions.outputs.action }}
+            from ${{ steps.update-github-actions.outputs.old-version }}
+            to ${{ steps.update-github-actions.outputs.new-version }}
+            in comments


### PR DESCRIPTION
- Run Dependabot monthly to update GitHub Actions versions
- Ensure version comments get updated
- Ensure `ci.yml` workflow is not run for Dependabot PRs