### PR TITLE
Fix Scala Steward CI on `ci.yml` workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Commit changes by `sbt generateCiFiles`
         uses: alejandrohdezma/actions/commit-and-push@v1
         with:
-          message: Run `sbt generateCiFiles`
+          message: Run `sbt generateCiFiles` [skip ci]
 
       - name: Run `sbt fix`
         uses: alejandrohdezma/actions/scala@v1
@@ -97,7 +97,7 @@ jobs:
       - name: Commit changes by `sbt fix`
         uses: alejandrohdezma/actions/commit-and-push@v1
         with:
-          message: Run `sbt fix`
+          message: Run `sbt fix` [skip ci]
 
   test:
     needs: [labeler, ci-steward]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2.3.5
         with:
           token: ${{ steps.github_app.outputs.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Enable auto-merge for this PR
         run: gh pr merge --auto --merge ${{github.event.pull_request.number}}


### PR DESCRIPTION
We should be checking out using the `github.event.pull_request.head.ref` as `ref`.