### PR TITLE
Fix `labeler` job when PR comes from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Update PR labels
         uses: alejandrohdezma/actions/labeler@v1
+        if: github.event.pull_request.head.repo.full_name == github.repository
 
       - name: Check PR labels
         uses: alejandrohdezma/actions/label-check@v1
@@ -74,7 +75,7 @@ jobs:
           message: Run `sbt fix`
 
   test:
-    needs: [labeler, ci-steward]
+    needs: [ci-steward]
     if: |
       always() && !contains(needs.*.result, 'failure') && github.event.pull_request.state == 'OPEN' &&
         github.actor != 'dependabot[bot]'


### PR DESCRIPTION
This job was failing when the PR came from a fork. This change should fix that.