### PR TITLE
Configurable Scala Steward Bot using variables

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,7 +5,7 @@ changelog:
     labels:
       - ":chart_with_upwards_trend: dependency-update"
     authors:
-      - alejandrohdezma-steward
+      - dependabot
   categories:
     - title: "⚠️ Breaking changes"
       labels:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # Runs `sbt ci-test` on the project on differnt JDKs (this task should be added to the project as a command alias
 # containing the necessary steps to compile, check formatters, launch tests...).
 #
-# An example of this `ci-test` alias can be found in https://github.com/alejandrohdezma/sbt-github/blob/main/build.sbt.
+# Examples of this `ci-test` alias can be found [here](https://github.com/search?q=org%3Aalejandrohdezma+%22ci-test%22+path%3Abuild.sbt++NOT+is%3Aarchived&type=code).
 #
 # It will also do the following:
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@
 # It will also do the following:
 #
 # - It will automatically label PRs based on head branch.
-# - It will automatically enable auto-merge on `Scala Steward` PRs.
+# - It will automatically enable auto-merge on `Scala Steward` PRs. You'll need to add a `STEWARD_BOT` repository or
+#   organization variable with the name of your scala-steward bot. See https://docs.github.com/en/actions/learn-github-actions/variables.
 
 name: CI
 
@@ -30,7 +31,7 @@ jobs:
   ci-steward:
     if: |
       github.event.pull_request.state == 'OPEN' && github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.user.login == 'alejandrohdezma-steward[bot]'
+        github.event.pull_request.user.login == vars.STEWARD_BOT
     name: (Scala Steward) Enable auto-merge
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
 # This workflow performs two tasks:
 #
 # - Creates a release of the project by running `sbt ci-publish` (this task should be added to the project as a command
-#   alias containing the necessary steps to do a release). An example of the `ci-publish` alias can be found in
-#   https://github.com/alejandrohdezma/sbt-github/blob/main/build.sbt.
+#   alias containing the necessary steps to do a release). Examples of this `ci-publish` alias can be found
+#   [here](https://github.com/search?q=org%3Aalejandrohdezma+%22ci-publish%22+path%3Abuild.sbt++NOT+is%3Aarchived&type=code).
 #
 # - Runs `sbt ci-docs` on the project and pushes a commit with the changes (the `ci-docs` task should be added to the
 #   project as a command alias containing the necessary steps to update documentation: re-generate docs files,
-#   publish websites, update headers...). An example of the `ci-docs` alias can be found in
-#   https://github.com/alejandrohdezma/sbt-github/blob/main/build.sbt.
+#   publish websites, update headers...). Examples of this `ci-docs` alias can be found
+#   [here](https://github.com/search?q=org%3Aalejandrohdezma+%22ci-docs%22+path%3Abuild.sbt++NOT+is%3Aarchived&type=code).
 #
 # This workflow will launch on pushed tags. Alternatively one can launch it manually using a "workflow dispatch" to
 # create a snapshot release (this won't trigger the documentation update).


### PR DESCRIPTION
Add support for configuring the Scala Steward bot name to something else than `alejandrohdezma-steward[bot]`.