### PR TITLE
Ensure `versionPolicyIntention` is reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
   documentation:
     needs: [release]
-    name: Updates documentation after latest release
+    name: Updates documentation and version policy after latest release
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -78,3 +78,14 @@ jobs:
         with:
           message: Run `sbt ci-docs` [skip ci]
           branch: main
+
+      - name: Reset `versionPolicyIntention`
+        run: sed -i -r 's/Compatibility\.(None|BinaryCompatible)/Compatibility.BinaryAndSourceCompatible/g' build.sbt
+
+      - name: Commit `versionPolicyIntention` reset
+        uses: alejandrohdezma/actions/commit-and-push@v1
+        with:
+          message: Reset `versionPolicyIntention` [skip ci]
+          branch: main
+      
+  

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,11 @@
 ThisBuild / scalaVersion                  := _root_.scalafix.sbt.BuildInfo.scala212
 ThisBuild / organization                  := "com.alejandrohdezma"
 ThisBuild / pluginCrossBuild / sbtVersion := "1.2.8"
+ThisBuild / versionPolicyIntention        := Compatibility.BinaryCompatible
 
-addCommandAlias("ci-test", "fix --check; mdoc; publishLocal")
+addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc; publishLocal")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")
-addCommandAlias("ci-publish", "github; ci-release")
+addCommandAlias("ci-publish", "versionCheck; github; ci-release")
 
 val `sbt-mdoc` = "org.scalameta" % "sbt-mdoc" % "[2.0,)" % Provided // scala-steward:off
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("ch.epfl.scala"       % "sbt-scalafix"          % "0.11.1")
+addSbtPlugin("ch.epfl.scala"       % "sbt-version-policy"    % "3.2.0")
 addSbtPlugin("com.alejandrohdezma" % "sbt-fix"               % "0.7.1")
 addSbtPlugin("com.alejandrohdezma" % "sbt-github-mdoc"       % "0.11.11")
 addSbtPlugin("com.alejandrohdezma" % "sbt-github-header"     % "0.11.11")


### PR DESCRIPTION
This change will reset `versionPolicyIntention` setting to `Compatibility.BinaryAndSourceCompatible` (if a project is using https://github.com/scalacenter/sbt-version-policy) after every release.