### PR TITLE
Add `sbt-version-policy`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,8 @@ addCommandAlias("ci-publish", "versionCheck; github; ci-release")
 
 val `sbt-mdoc` = "org.scalameta" % "sbt-mdoc" % "[2.0,)" % Provided // scala-steward:off
 
+val `sbt-version-policy` = "ch.epfl.scala" % "sbt-version-policy" % "[3.2,)" % Provided // scala-steward:off
+
 lazy val documentation = project
   .enablePlugins(MdocPlugin)
   .settings(mdocIn := file(".github") / "docs")
@@ -17,6 +19,7 @@ lazy val documentation = project
 
 lazy val `sbt-ci` = module
   .settings(addSbtPlugin(`sbt-mdoc`))
+  .settings(addSbtPlugin(`sbt-version-policy`))
   .enablePlugins(SbtPlugin)
   .enablePlugins(BuildInfoPlugin)
   .settings(buildInfoKeys += BuildInfoKey("repo", repository.value.map(_.name)))

--- a/modules/sbt-ci/src/main/scala/sbt/ci/SbtCiPlugin.scala
+++ b/modules/sbt-ci/src/main/scala/sbt/ci/SbtCiPlugin.scala
@@ -22,6 +22,8 @@ import sbt.Keys.streams
 import sbt._
 
 import com.alejandrohdezma.resource.generator.ResourceGenerator
+import sbtversionpolicy.SbtVersionPolicyPlugin
+import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport.versionPolicyIgnoredInternalDependencyVersions
 
 /** This plugin generates (or updates) a bunch of files common to several projects. */
 object SbtCiPlugin extends AutoPlugin with ResourceGenerator[Unit] {
@@ -41,6 +43,8 @@ object SbtCiPlugin extends AutoPlugin with ResourceGenerator[Unit] {
 
   override def trigger = allRequirements
 
+  override def requires: Plugins = SbtVersionPolicyPlugin
+
   import autoImport._
 
   override def buildSettings = Seq(
@@ -51,7 +55,8 @@ object SbtCiPlugin extends AutoPlugin with ResourceGenerator[Unit] {
         excludeFile = globPatterns.value,
         logger = streams.value.log.info(_)
       )
-    }
+    },
+    versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
   )
 
   private val globPatterns = Def.setting {


### PR DESCRIPTION
Adds https://github.com/scalacenter/sbt-version-policy as well as sets a default value for the `versionPolicyIgnoredInternalDependencyVersions` key so it works correctly with projects using sbt-dynver.